### PR TITLE
Without RunAs module ? 

### DIFF
--- a/lib/openvpn-bin.js
+++ b/lib/openvpn-bin.js
@@ -1,7 +1,7 @@
 var Promise = require('bluebird');
 var _ = require('lodash');
 var path = require('path');
-var runas = require('runas');
+var child_process = require('child_process');
 var getPort = Promise.promisify(require('get-port'));
 var fs = Promise.promisifyAll(require('fs'));
 
@@ -50,11 +50,7 @@ function initialize(openvpnpath, args) {
             })
             .then(getSetArgs)
             .then(function(setargs) {
-                return runas(openvpnpath, setargs, {
-                    admin: true,
-                    hide: false,
-                    catchOutput: true
-                });
+                return child_process.execFileSync(openvpnpath,setargs);
             })
             .then(function() {
                 resolve({

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "dependencies": {
         "bluebird": "^2.9.34",
         "get-port": "^1.0.0",
-        "lodash": "^3.10.1",
-        "runas": "^3.1.0"
+        "lodash": "^3.10.1"
     },
     "devDependencies": {
         "minimist": "^1.2.0"

--- a/test.js
+++ b/test.js
@@ -2,9 +2,19 @@ var openvpnbin = require('./lib/openvpn-bin.js');
 var argv = require('minimist')(process.argv.slice(2));
 var path = require('path');
 
-
 if (argv.init) {
-    var openvpnpath = path.normalize('../bin/openvpn.exe'), //path of openvpn exsecutable
+    var openvpnpath = path.normalize(getOpenVPNPath()), //path of openvpn exsecutable
+        args = {
+            host: '127.0.0.1',
+            port: 1337,
+            scriptSecurity: 2,
+            config: 'config.ovpn'
+        };
+    console.log(openvpnbin.initialize(openvpnpath, args));
+}
+
+if (argv.shutdown) {
+    var openvpnpath = path.normalize(getOpenVPNPath()),
         args = {
             host: '127.0.0.1',
             port: 1337,
@@ -14,13 +24,15 @@ if (argv.init) {
     openvpnbin.initialize(openvpnpath, args);
 }
 
-if (argv.shutdown) {
-    var openvpnpath = path.normalize('bin/openvpn.exe'),
-        args = {
-            host: '127.0.0.1',
-            port: 1337,
-            scriptSecurity: 2,
-            config: 'config.ovpn'
-        };
-    openvpnbin.initialize(openvpnpath, args);
+function getOpenVPNPath() {
+    switch (process.platform) {
+        case 'win32':
+            return '../bin/openvpn.exe'
+            break;
+        case 'darwin':
+            return '/usr/local/opt/openvpn/sbin/openvpn';
+        case 'linux':
+            return '/usr/local/opt/openvpn/sbin/openvpn';
+            break;
+    }    
 }


### PR DESCRIPTION
Hi, 

I would used your NPM module but when I try to install all dependencies, I had an error with RunAs and Python. It seems that RunAS has a dependency with node-gyp. 

Maybe runAs module isn't still necessary. In this pull request I would propose to use child_process instead. 

The only difference with RunAS is about the admin privilege. If user needs admin privilege they need to launch the main process with sudo command. 

Please tell me if you valid this request.

Regards,